### PR TITLE
Reimplemented check scanning and added a function to retrieve all moves for a piece

### DIFF
--- a/Models/ChessBoard.cs
+++ b/Models/ChessBoard.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
@@ -206,7 +206,7 @@ public class ChessBoard
         rook.HasMoved = true;
 
         // Update turn and notify
-        _isWhiteTurn = !_isWhiteTurn;
+        IsWhiteTurn = !IsWhiteTurn;
         GridUpdated?.Invoke();
     }
 

--- a/Models/ChessBoard.cs
+++ b/Models/ChessBoard.cs
@@ -6,18 +6,18 @@ namespace L_0_Chess_Engine.Models;
 
 public class ChessBoard
 {
-    public ChessPiece[,] Grid { get; set; }
-    public bool IsCheck { get => CheckScan(); }
-    public bool IsCheckMate { get; set; }
-
     //Constant FEN for the starting position
     private const string DefaultFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
+    
+    public ChessPiece[,] Grid { get; set; }
+
+    public bool IsCheck { get => CheckScan(); }
+    public bool IsCheckMate { get; set; }
 
     // Invoked every time grid updates
     public event Action? GridUpdated;
 
     public bool IsWhiteTurn { get; set; }
-
 
     private static ChessBoard? _instance;
     public static ChessBoard Instance
@@ -76,17 +76,7 @@ public class ChessBoard
     // After making a move, it checks if the opposite team is in check
     private bool CheckScan()
     {
-        PieceType oppositeColour;
-
-        if (IsWhiteTurn)
-        {
-            oppositeColour = PieceType.Black;
-        }
-        else
-        {
-            oppositeColour = PieceType.White;
-        }
-
+        PieceType oppositeColour = IsWhiteTurn ? PieceType.Black : PieceType.White;
 
         for (int x = 0; x < 8; x++)
         {
@@ -138,7 +128,6 @@ public class ChessBoard
 
     public bool ReadFEN(string fen)
     {
-
         // Split the layout into rows (8 rows for an 8x8 board)
         var rows = fen.Split('/');
         if (rows.Length != 8)

--- a/Models/ChessPiece.cs
+++ b/Models/ChessPiece.cs
@@ -25,7 +25,8 @@ public class ChessPiece
     public Coordinate Coordinates { get; set; }
     public bool HasMoved { get; set; }
     public bool IsValidPassantPlacement { get; set; }
-    public bool IsWhite { get => (Type & PieceType.White) == PieceType.White; }
+    public bool IsWhite { get => (Type & PieceType.White) == PieceType.White; } // remove this later and just use the Color property
+    public PieceType Color { get => GetColor(); }
 
     // Constructors
 
@@ -33,7 +34,7 @@ public class ChessPiece
     {
         Type = PieceType.White | PieceType.Pawn;
         Coordinates = new(0, 0);
-        
+
         HasMoved = false;
         IsValidPassantPlacement = false;
     }
@@ -47,6 +48,18 @@ public class ChessPiece
         IsValidPassantPlacement = false;
     }
 
+    private PieceType GetColor()
+    {
+        PieceType mask = PieceType.White | PieceType.Black;
+        if ((Type & mask) == PieceType.White)
+        {
+            return PieceType.White;
+        }
+        else
+        {
+            return PieceType.Black;
+        }
+    }
     public bool EqualsUncolored(PieceType type) => IsWhite ? (Type ^ PieceType.White) == type : (Type ^ PieceType.Black) == type; 
 
     public static bool operator ==(ChessPiece A, PieceType B) => A.Type == B;

--- a/Models/Move.cs
+++ b/Models/Move.cs
@@ -285,8 +285,6 @@ public class Move
     public static List<Move> GetPossibleMoves(ChessPiece piece)
     {
         PieceType color = piece.Color;
-        PieceType oppositeColor = piece.IsWhite ? PieceType.Black : PieceType.White;
-
         PieceType type = piece.Type ^ color;
 
         (int auraX, int auraY) = AuraMap[type];
@@ -311,8 +309,6 @@ public class Move
                 }
 
                 Move move = new(piece, ChessBoard.Instance.Grid[totalX, totalY]);
-
-                Console.WriteLine($"MOVE CREATED: {move.InitPiece.Type}: {move.InitPiece.Coordinates} | {move.DestPiece.Coordinates}");
 
                 if (move.IsValid)
                 {

--- a/Models/Move.cs
+++ b/Models/Move.cs
@@ -10,6 +10,8 @@ public class Move
     public ChessPiece InitPiece { get; set; }
     public ChessPiece DestPiece { get; set; }
 
+    public bool TargetsKing { get => DestPiece.EqualsUncolored(PieceType.King); }
+
     public bool IsEnPassant { get; set; }
 
     /// <summary>
@@ -17,6 +19,13 @@ public class Move
     /// and returns true if the move is valid
     /// </summary>
     private static Dictionary<PieceType, Func<Move, bool>> ValidationMap = [];
+
+    /// <summary>
+    /// Takes in an uncolored piecetype, and returns a coordinate object that 
+    /// represents the absolute units that the piece is allowed to move
+    /// </summary>
+    private static Dictionary<PieceType, Coordinate> AuraMap = [];
+
     static Move()
     {
         ValidationMap[PieceType.Pawn] = IsValidPawnMove;
@@ -25,6 +34,13 @@ public class Move
         ValidationMap[PieceType.Bishop] = IsValidBishopMove;
         ValidationMap[PieceType.Queen] = IsValidQueenMove;
         ValidationMap[PieceType.King] = IsValidKingMove;
+
+        AuraMap[PieceType.Pawn] = new(1, 2);
+        AuraMap[PieceType.Knight] = new(2, 2);
+        AuraMap[PieceType.Rook] = new(8, 8);
+        AuraMap[PieceType.Bishop] = new(8, 8);
+        AuraMap[PieceType.Queen] = new(8, 8);
+        AuraMap[PieceType.King] = new(1, 1);
     }
 
     /// <param name="initial">Starting coordinate</param>
@@ -66,12 +82,6 @@ public class Move
 
         // Cannot capture same team
         if (move.DestPiece != PieceType.Empty && (move.DestPiece.IsWhite == move.InitPiece.IsWhite))
-        {
-            return false;
-        }
-
-        // Cannot capture king
-        if (move.DestPiece.EqualsUncolored(PieceType.King))
         {
             return false;
         }
@@ -140,7 +150,6 @@ public class Move
         if (Math.Abs(destX - initX) == 2 && Math.Abs(destY - initY) == 1)
         {
             return true;
-
         }
         if (Math.Abs(destX - initX) == 1 && Math.Abs(destY - initY) == 2)
         {
@@ -179,7 +188,6 @@ public class Move
                 }
             }
         }
-
         else if (IsValidVertical)
         {
             int start = Math.Min(InitY, DestY) + 1;
@@ -193,8 +201,10 @@ public class Move
                 }
             }
         }
-
-        else if (!IsValidHorizontal && !IsValidVertical) return false;
+        else if (!IsValidHorizontal && !IsValidVertical)
+        {
+            return false;
+        }
 
         return true;
     }
@@ -272,4 +282,47 @@ public class Move
 
         return true;
     }
+
+    public static List<Move> GetPossibleMoves(ChessPiece piece)
+    {
+        PieceType color = piece.Color;
+        PieceType oppositeColor = piece.IsWhite ? PieceType.Black : PieceType.White;
+
+        PieceType type = piece.Type ^ color;
+
+        (int auraX, int auraY) = AuraMap[type];
+
+        List<Move> validMoves = [];
+
+        for (int dX = -auraX; dX <= auraX; dX++)
+        {
+            for (int dY = -auraY; dY <= auraY; dY++)
+            {
+                int totalX = dX + piece.Coordinates.X;
+                int totalY = dY + piece.Coordinates.Y;
+
+                if (totalX < 0 || totalX >= 8 || totalY < 0 || totalY >= 8)
+                {
+                    continue;
+                }
+
+                if (type == PieceType.Rook && dX != 0 && dY != 0) // skip any diagonal moves for rook - automatically invalid
+                {
+                    continue;
+                }
+
+                Move move = new(piece, ChessBoard.Instance.Grid[totalX, totalY]);
+
+                Console.WriteLine($"MOVE CREATED: {move.InitPiece.Type}: {move.InitPiece.Coordinates} | {move.DestPiece.Coordinates}");
+
+                if (move.IsValid)
+                {
+                    validMoves.Add(move);
+                }
+            }
+        }
+
+        return validMoves;
+    }
+
 }

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -113,7 +113,7 @@ public partial class GameViewModel : ObservableObject
         {
             Move move = new(_selectedSquare!.Piece, squareClicked.Piece);
 
-            if (!move.IsValid)
+            if (!move.IsValid || move.TargetsKing)
             {
                 _selectedSquare.IsSelected = false;
                 _selectedSquare = null;
@@ -126,6 +126,7 @@ public partial class GameViewModel : ObservableObject
 
             _selectedSquare.IsSelected = false;
             _selectedSquare = null;
+
             UpdateGameStateText();
         }
     }


### PR DESCRIPTION
Added some properties to aid in code readabilty:

* ChessPiece.Color - To compare color directly rather than having to use bitwise operations everywhere
Note: This means we can get rid of IsWhite later to reduce redundancy, but we can do this later in the cleanup period
* Move.TargetsKing - Move is now no longer invalid directly when it is targetting king. Instead, the frontend locks king killing to allow searching for valid moves that attack the king more easily. I tried other implementations where Move.IsValid was still false if it was targetting the king, but that got very messy